### PR TITLE
update url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@
 
 ### For User
 
-我们已经将该项目部署到一台校内服务器中，暂未配置域名。但同学们可以在校内网络的环境下通过下面链接访问。
+我们已经将该项目部署到cloudflare pages中，同学们可以通过下面链接访问。
 
-[《XJTU计算机系自救与生存指南》](http://115.154.246.169:8081/)
+- [https://survivexjtucs.pages.dev/](https://survivexjtucs.pages.dev/)
+- [https://survive.ymzymz.me/](https://survive.ymzymz.me/)
 
 <br/>
 


### PR DESCRIPTION
原来README中校内地址已经失效. 我将它部署到了cloudflare pages中.
survivexjtucs.pages.dev会长期保留, survive.ymzymz.me年底域名可能会过期.

目前访问, 学校校徽加载不出来, 因为校徽链接`http://vi.xjtu.edu.cn/images/a1-3jdxhred.png`不支持https. 后续可以考虑将校徽作为图片保存在repo中, 而不是调用外部链接